### PR TITLE
fix part names, skill names, skill slugs in parts

### DIFF
--- a/content/arms-armors.json
+++ b/content/arms-armors.json
@@ -2157,9 +2157,9 @@
         "slug": "Spare-Shot"
       },
       {
-        "name": "Aim Booster",
+        "name": "Ballistics",
         "level": 1,
-        "slug": "Aim-Booster"
+        "slug": "Ballistics"
       }
     ],
     "slots": [],
@@ -2988,10 +2988,10 @@
     "rank": 2
   },
   {
-    "name": "Chaunmail Gloves X",
-    "url": "/Chaunmail+Gloves+X",
+    "name": "Chainmail Gloves X",
+    "url": "/Chainmail+Gloves+X",
     "type": "arms",
-    "slug": "Chaunmail-Gloves-X",
+    "slug": "Chainmail-Gloves-X",
     "skills": [
       {
         "name": "Stamina Surge",

--- a/content/chest-armors.json
+++ b/content/chest-armors.json
@@ -306,7 +306,7 @@
       {
         "name": "Water Resistance",
         "level": 1,
-        "slug": "Water-Resistance"
+        "slug": "Water-Resistance-Skill"
       }
     ],
     "slots": [],
@@ -479,7 +479,7 @@
       {
         "name": "Fire Resistance",
         "level": 2,
-        "slug": "Fire-Resistance"
+        "slug": "Fire-Resistance-Skill"
       }
     ],
     "slots": [],
@@ -3801,7 +3801,7 @@
       {
         "name": "Fire Resistance",
         "level": 2,
-        "slug": "Fire-Resistance"
+        "slug": "Fire-Resistance-Skill"
       },
       {
         "name": "Recovery Speed",
@@ -6788,7 +6788,7 @@
       {
         "name": "Elemental Exploit",
         "level": 1,
-        "slug": "Elemental-Exploit"
+        "slug": "Element-Exploit"
       },
       {
         "name": "Critical Element",
@@ -7068,7 +7068,7 @@
       {
         "name": "Dragon Resistance",
         "level": 3,
-        "slug": "Dragon-Resistance"
+        "slug": "Dragon-Resistance-Skill"
       },
       {
         "name": "Attack Boost",

--- a/content/decorations.json
+++ b/content/decorations.json
@@ -1024,7 +1024,7 @@
     "slug": "Hard-Fire-Res-Jewel-4",
     "url": "/Hard+Fire+Res+Jewel+4",
     "skill": "Fire Resistance",
-    "skillSlug": "Fire-Resistance",
+    "skillSlug": "Fire-Resistance-Skill",
     "skillLevel": 3,
     "level": 4,
     "isRampage": false
@@ -1054,7 +1054,7 @@
     "slug": "Hard-Ice-Res-Jewel-4",
     "url": "/Hard+Ice+Res+Jewel+4",
     "skill": "Ice Resistance",
-    "skillSlug": "Ice-Resistance",
+    "skillSlug": "Ice-Resistance-Skill",
     "skillLevel": 3,
     "level": 4,
     "isRampage": false
@@ -1064,7 +1064,7 @@
     "slug": "Hard-Dragon-Res-Jewel-4",
     "url": "/Hard+Dragon+Res+Jewel+4",
     "skill": "Dragon Resistance",
-    "skillSlug": "Dragon-Resistance",
+    "skillSlug": "Dragon-Resistance-Skill",
     "skillLevel": 3,
     "level": 4,
     "isRampage": false

--- a/content/head-armors.json
+++ b/content/head-armors.json
@@ -606,7 +606,7 @@
       {
         "name": "Dragon Resistance",
         "level": 2,
-        "slug": "Dragon-Resistance"
+        "slug": "Dragon-Resistance-Skill"
       }
     ],
     "slots": [],
@@ -648,7 +648,7 @@
       {
         "name": "Water Resistance",
         "level": 1,
-        "slug": "Water-Resistance"
+        "slug": "Water-Resistance-Skill"
       }
     ],
     "slots": [],
@@ -1941,9 +1941,9 @@
     "slug": "S.-Studded-Hat-S",
     "skills": [
       {
-        "name": "Aim Booster",
+        "name": "Ballistics",
         "level": 2,
-        "slug": "Aim-Booster"
+        "slug": "Ballistics"
       }
     ],
     "slots": [],
@@ -3561,7 +3561,7 @@
       {
         "name": "Ice Resistance",
         "level": 1,
-        "slug": "Ice-Resistance"
+        "slug": "Ice-Resistance-Skill"
       }
     ],
     "slots": [
@@ -7036,7 +7036,7 @@
       {
         "name": "Elemental Exploit",
         "level": 1,
-        "slug": "Elemental-Exploit"
+        "slug": "Element-Exploit"
       }
     ],
     "slots": [

--- a/content/legs-armors.json
+++ b/content/legs-armors.json
@@ -265,7 +265,7 @@
       {
         "name": "Water Resistance",
         "level": 2,
-        "slug": "Water-Resistance"
+        "slug": "Water-Resistance-Skill"
       }
     ],
     "slots": [],
@@ -2206,9 +2206,9 @@
         "slug": "Constitution"
       },
       {
-        "name": "Aim Booster",
+        "name": "Ballistics",
         "level": 1,
-        "slug": "Aim-Booster"
+        "slug": "Ballistics"
       }
     ],
     "slots": [],
@@ -3366,7 +3366,7 @@
       {
         "name": "Ice Resistance",
         "level": 2,
-        "slug": "Ice-Resistance"
+        "slug": "Ice-Resistance-Skill"
       }
     ],
     "slots": [

--- a/content/waist-armors.json
+++ b/content/waist-armors.json
@@ -438,7 +438,7 @@
       {
         "name": "Fire Resistance",
         "level": 1,
-        "slug": "Fire-Resistance"
+        "slug": "Fire-Resistance-Skill"
       }
     ],
     "slots": [],
@@ -548,7 +548,7 @@
       {
         "name": "Dragon Resistance",
         "level": 1,
-        "slug": "Dragon-Resistance"
+        "slug": "Dragon-Resistance-Skill"
       }
     ],
     "slots": [],
@@ -588,9 +588,9 @@
     "slug": "S.-Studded-Sash",
     "skills": [
       {
-        "name": "Aim Booster",
+        "name": "Ballistics",
         "level": 1,
-        "slug": "Aim-Booster"
+        "slug": "Ballistics"
       }
     ],
     "slots": [],
@@ -1775,9 +1775,9 @@
     "slug": "S.-Studded-Sash-S",
     "skills": [
       {
-        "name": "Aim Booster",
+        "name": "Ballistics",
         "level": 1,
-        "slug": "Aim-Booster"
+        "slug": "Ballistics"
       }
     ],
     "slots": [],
@@ -3386,7 +3386,7 @@
       {
         "name": "Dragon Resistance",
         "level": 3,
-        "slug": "Dragon-Resistance"
+        "slug": "Dragon-Resistance-Skill"
       }
     ],
     "slots": [


### PR DESCRIPTION
Fix typo in armor parts "Chaunmail".
Fix armor part skill "Aim Booster" should be "Ballistics" from skills.json.
Fix armor part skills slugs to match those in skills.json.
